### PR TITLE
feat: add Kubernetes foundation with PostgreSQL and 1Password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: help build-postgres push-postgres deploy destroy psql logs-postgres port-forward-postgres
+
+NAMESPACE := eleduck-analytics
+POSTGRES_POD := $(shell kubectl get pods -n $(NAMESPACE) -l app=postgres -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# Docker builds
+build-postgres: ## Build postgres-duckdb Docker image
+	cd docker/postgres-duckdb && docker buildx bake -f docker-bake.hcl
+
+push-postgres: ## Push postgres-duckdb Docker image to GHCR
+	cd docker/postgres-duckdb && docker buildx bake -f docker-bake.hcl --push
+
+# Kubernetes operations
+deploy: ## Deploy all infrastructure to Kubernetes
+	kubectl apply -k k8s/
+
+destroy: ## Remove all infrastructure from Kubernetes
+	kubectl delete -k k8s/ --ignore-not-found
+
+# PostgreSQL operations
+psql: ## Connect to PostgreSQL via kubectl exec
+	@if [ -z "$(POSTGRES_POD)" ]; then echo "No postgres pod found"; exit 1; fi
+	kubectl exec -it -n $(NAMESPACE) $(POSTGRES_POD) -- psql -U $$(kubectl get secret -n $(NAMESPACE) postgres-credentials -o jsonpath='{.data.username}' | base64 -d) -d $$(kubectl get secret -n $(NAMESPACE) postgres-credentials -o jsonpath='{.data.database}' | base64 -d)
+
+logs-postgres: ## Tail PostgreSQL logs
+	kubectl logs -f -n $(NAMESPACE) -l app=postgres
+
+port-forward-postgres: ## Port forward PostgreSQL to localhost:5432
+	kubectl port-forward -n $(NAMESPACE) svc/postgres 5432:5432
+
+# Status checks
+status: ## Show status of all pods
+	kubectl get pods -n $(NAMESPACE)
+
+secrets: ## List secrets in namespace
+	kubectl get secrets -n $(NAMESPACE)
+
+describe-postgres: ## Describe postgres deployment
+	kubectl describe deployment -n $(NAMESPACE) postgres

--- a/docker/postgres-duckdb/Dockerfile
+++ b/docker/postgres-duckdb/Dockerfile
@@ -1,0 +1,38 @@
+FROM postgres:16-bookworm
+
+LABEL org.opencontainers.image.source="https://github.com/Soypete/eleduck-analytics-connector"
+LABEL org.opencontainers.image.description="PostgreSQL 16 with pg_duckdb extension"
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libreadline-dev \
+    zlib1g-dev \
+    postgresql-server-dev-16 \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and build pg_duckdb
+WORKDIR /tmp
+RUN git clone --depth 1 https://github.com/duckdb/pg_duckdb.git \
+    && cd pg_duckdb \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/pg_duckdb
+
+# Add pg_duckdb to shared_preload_libraries
+RUN echo "shared_preload_libraries = 'pg_duckdb'" >> /usr/share/postgresql/postgresql.conf.sample
+
+# Clean up build dependencies to reduce image size
+RUN apt-get remove -y \
+    build-essential \
+    cmake \
+    git \
+    postgresql-server-dev-16 \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+WORKDIR /

--- a/docker/postgres-duckdb/docker-bake.hcl
+++ b/docker/postgres-duckdb/docker-bake.hcl
@@ -1,0 +1,27 @@
+variable "REGISTRY" {
+  default = "ghcr.io"
+}
+
+variable "REPO" {
+  default = "soypete/postgres-duckdb"
+}
+
+variable "TAG" {
+  default = "16"
+}
+
+group "default" {
+  targets = ["postgres-duckdb"]
+}
+
+target "postgres-duckdb" {
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${REGISTRY}/${REPO}:${TAG}",
+    "${REGISTRY}/${REPO}:latest"
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = ["type=gha"]
+  cache-to   = ["type=gha,mode=max"]
+}

--- a/k8s/1password/onepassworditem-airbyte.yaml
+++ b/k8s/1password/onepassworditem-airbyte.yaml
@@ -1,0 +1,2 @@
+# Airbyte source credentials - configured in Plan 2
+# Each source will have its own OnePasswordItem

--- a/k8s/1password/onepassworditem-postgres.yaml
+++ b/k8s/1password/onepassworditem-postgres.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: postgres-credentials
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/eleduck-postgres"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: eleduck-analytics
+
+resources:
+  - namespace.yaml
+  - 1password/onepassworditem-postgres.yaml
+  - postgres/

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eleduck-analytics
+  labels:
+    app.kubernetes.io/name: eleduck-analytics
+    app.kubernetes.io/part-of: eleduck-analytics-stack

--- a/k8s/postgres/configmap-init.yaml
+++ b/k8s/postgres/configmap-init.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-scripts
+  namespace: eleduck-analytics
+data:
+  01-init-schemas.sql: |
+    -- Create schemas for data warehouse layers
+    CREATE SCHEMA IF NOT EXISTS raw;
+    CREATE SCHEMA IF NOT EXISTS staging;
+    CREATE SCHEMA IF NOT EXISTS analytics;
+
+    -- Grant usage to the main user
+    GRANT ALL ON SCHEMA raw TO CURRENT_USER;
+    GRANT ALL ON SCHEMA staging TO CURRENT_USER;
+    GRANT ALL ON SCHEMA analytics TO CURRENT_USER;
+
+    -- Create additional databases
+    CREATE DATABASE airbyte_internal;
+    CREATE DATABASE metabase_app;
+
+  02-enable-pg-duckdb.sql: |
+    -- Enable pg_duckdb extension
+    CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+
+    -- Note: To use DuckDB for analytical queries, set:
+    -- SET duckdb.execution = true;
+    -- This can be done per-session or per-query

--- a/k8s/postgres/deployment.yaml
+++ b/k8s/postgres/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: eleduck-analytics
+  labels:
+    app: postgres
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    type: Recreate  # Required for RWO PVC
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: ghcr.io/soypete/postgres-duckdb:16
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: database
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data
+        - name: init-scripts
+          configMap:
+            name: postgres-init-scripts

--- a/k8s/postgres/kustomization.yaml
+++ b/k8s/postgres/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - configmap-init.yaml
+  - deployment.yaml
+  - service.yaml

--- a/k8s/postgres/pvc.yaml
+++ b/k8s/postgres/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: eleduck-analytics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  # storageClassName: standard  # Uncomment and adjust for your cluster

--- a/k8s/postgres/service.yaml
+++ b/k8s/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: eleduck-analytics
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres
+  selector:
+    app: postgres

--- a/scripts/enable-pg-duckdb.sql
+++ b/scripts/enable-pg-duckdb.sql
@@ -1,0 +1,11 @@
+-- Enable pg_duckdb extension for analytical queries
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+
+-- To use DuckDB execution mode for a session:
+-- SET duckdb.execution = true;
+
+-- To use DuckDB for a single query, wrap it:
+-- SELECT * FROM duckdb.query('SELECT ...');
+
+-- Check if extension is loaded
+SELECT * FROM pg_extension WHERE extname = 'pg_duckdb';

--- a/scripts/init-schemas.sql
+++ b/scripts/init-schemas.sql
@@ -1,0 +1,15 @@
+-- Initialize database schemas for eleduck-analytics
+-- This script is also embedded in the ConfigMap but kept here for reference
+
+-- Create schemas for data warehouse layers
+CREATE SCHEMA IF NOT EXISTS raw;
+CREATE SCHEMA IF NOT EXISTS staging;
+CREATE SCHEMA IF NOT EXISTS analytics;
+
+-- Grant usage to the main user
+GRANT ALL ON SCHEMA raw TO CURRENT_USER;
+GRANT ALL ON SCHEMA staging TO CURRENT_USER;
+GRANT ALL ON SCHEMA analytics TO CURRENT_USER;
+
+-- Set default search path
+ALTER DATABASE analytics SET search_path TO analytics, staging, raw, public;


### PR DESCRIPTION
- Add eleduck-analytics namespace with kustomize configuration
- Add PostgreSQL deployment with pg_duckdb extension support
- Add 1Password integration for secret management
- Add postgres-duckdb Dockerfile with multi-arch build support
- Add Makefile for common operations

Note: GitHub Actions workflow (build-postgres.yaml) needs to be
added separately with elevated permissions.

Creates schemas: raw, staging, analytics
Creates databases: analytics, airbyte_internal, metabase_app