### PR TITLE
feat: add Airbyte deployment with source configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help build-postgres push-postgres deploy destroy psql logs-postgres port-forward-postgres
+.PHONY: help build-postgres push-postgres deploy destroy psql logs-postgres port-forward-postgres \
+	deploy-airbyte uninstall-airbyte port-forward-airbyte logs-airbyte-server logs-airbyte-worker airbyte-pods
 
 NAMESPACE := eleduck-analytics
 POSTGRES_POD := $(shell kubectl get pods -n $(NAMESPACE) -l app=postgres -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
@@ -40,3 +41,28 @@ secrets: ## List secrets in namespace
 
 describe-postgres: ## Describe postgres deployment
 	kubectl describe deployment -n $(NAMESPACE) postgres
+
+# Airbyte operations
+deploy-airbyte: ## Deploy Airbyte via Helm
+	helm repo add airbyte https://airbytehq.github.io/helm-charts || true
+	helm repo update
+	helm upgrade --install airbyte airbyte/airbyte \
+		-f k8s/airbyte/values.yaml \
+		-n $(NAMESPACE) \
+		--wait --timeout 10m
+
+uninstall-airbyte: ## Uninstall Airbyte
+	helm uninstall airbyte -n $(NAMESPACE) || true
+
+port-forward-airbyte: ## Port forward Airbyte UI to localhost:8080
+	@echo "Airbyte UI available at http://localhost:8080"
+	kubectl port-forward svc/airbyte-airbyte-webapp-svc 8080:80 -n $(NAMESPACE)
+
+logs-airbyte-server: ## Tail Airbyte server logs
+	kubectl logs -f deploy/airbyte-server -n $(NAMESPACE)
+
+logs-airbyte-worker: ## Tail Airbyte worker logs
+	kubectl logs -f -l airbyte=worker -n $(NAMESPACE)
+
+airbyte-pods: ## List Airbyte pods
+	kubectl get pods -n $(NAMESPACE) -l app.kubernetes.io/name=airbyte

--- a/airbyte/README.md
+++ b/airbyte/README.md
@@ -1,0 +1,182 @@
+# Airbyte Configuration
+
+This directory contains configuration templates for Airbyte sources and destinations.
+
+## Deployment
+
+Airbyte is deployed via Helm:
+
+```bash
+# Add Airbyte Helm repo
+helm repo add airbyte https://airbytehq.github.io/helm-charts
+helm repo update
+
+# Deploy Airbyte
+helm upgrade --install airbyte airbyte/airbyte \
+  -f k8s/airbyte/values.yaml \
+  -n eleduck-analytics
+
+# Wait for pods to be ready
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=airbyte -n eleduck-analytics --timeout=300s
+```
+
+## Accessing the UI
+
+```bash
+# Port forward to local machine
+make port-forward-airbyte
+
+# Open http://localhost:8080
+```
+
+## Setting Up Sources
+
+### Prerequisites
+
+Create 1Password items for each source. Required fields vary by source.
+
+### YouTube Analytics
+
+1Password item: `airbyte-youtube`
+- `client_id` - Google OAuth client ID
+- `client_secret` - Google OAuth client secret
+- `refresh_token` - OAuth refresh token
+
+Setup:
+1. Create OAuth 2.0 credentials in Google Cloud Console
+2. Enable YouTube Analytics API
+3. Generate refresh token using OAuth playground
+
+### Twitch
+
+1Password item: `airbyte-twitch`
+- `client_id` - Twitch application client ID
+- `client_secret` - Twitch application client secret
+- `user_id` - Your Twitch user ID
+
+Setup:
+1. Create application at https://dev.twitch.tv/console
+2. Get user ID from Twitch API or third-party tool
+
+### Twitter/X
+
+1Password item: `airbyte-twitter`
+- `api_key` - Twitter API key
+- `api_secret` - Twitter API secret
+- `bearer_token` - Bearer token for API v2
+
+**Note:** Twitter API now requires paid access ($100/month minimum).
+
+### LinkedIn
+
+1Password item: `airbyte-linkedin`
+- `client_id` - LinkedIn app client ID
+- `client_secret` - LinkedIn app client secret
+- `refresh_token` - OAuth refresh token
+- `organization_id` - Company page ID
+
+Setup:
+1. Create app at LinkedIn Developer Portal
+2. Request Marketing Developer Platform access
+3. Add company page to app
+
+### GitHub
+
+1Password item: `airbyte-github`
+- `personal_access_token` - Classic PAT with repo, read:org, read:user scopes
+
+Setup:
+1. Generate PAT at https://github.com/settings/tokens
+2. Select scopes: repo, read:org, read:user
+
+### Stripe
+
+1Password item: `airbyte-stripe`
+- `secret_key` - Stripe secret key (use restricted key)
+- `account_id` - Stripe account ID
+
+Setup:
+1. Get keys from Stripe Dashboard > Developers > API keys
+2. Create restricted key with read-only access
+
+### Notion
+
+1Password item: `airbyte-notion`
+- `api_token` - Notion integration token
+
+Setup:
+1. Create integration at https://www.notion.so/my-integrations
+2. Share relevant pages/databases with integration
+
+## Connection Naming Convention
+
+- Source: `src_<platform>` (e.g., `src_youtube`, `src_github`)
+- Destination: `dest_postgres_raw`
+- Connection: `<platform>_to_postgres` (e.g., `youtube_to_postgres`)
+
+## Sync Schedule
+
+All sources sync daily at 2am UTC, before DBT runs at 6am UTC.
+
+## Expected Raw Tables
+
+After syncing, these tables will appear in the `raw` schema:
+
+### YouTube
+- `raw.youtube_videos`
+- `raw.youtube_channel_stats`
+- `raw.youtube_video_metrics`
+
+### Twitch
+- `raw.twitch_streams`
+- `raw.twitch_followers`
+- `raw.twitch_videos`
+
+### Twitter
+- `raw.twitter_tweets`
+- `raw.twitter_user_metrics`
+
+### LinkedIn
+- `raw.linkedin_posts`
+- `raw.linkedin_page_stats`
+
+### GitHub
+- `raw.github_repositories`
+- `raw.github_commits`
+- `raw.github_pull_requests`
+- `raw.github_issues`
+- `raw.github_stargazers`
+
+### Stripe
+- `raw.stripe_charges`
+- `raw.stripe_customers`
+- `raw.stripe_subscriptions`
+- `raw.stripe_invoices`
+
+### Notion
+- `raw.notion_pages`
+- `raw.notion_databases`
+
+## Troubleshooting
+
+### Sync Failures
+
+Check connector logs:
+```bash
+kubectl logs -n eleduck-analytics -l airbyte=worker -f
+```
+
+### Connection Issues
+
+Verify PostgreSQL is accessible:
+```bash
+kubectl exec -it deploy/airbyte-server -n eleduck-analytics -- \
+  nc -zv postgres.eleduck-analytics.svc.cluster.local 5432
+```
+
+### Rate Limiting
+
+Most APIs have rate limits. Airbyte handles retries, but for persistent issues:
+- Check API quotas in provider's dashboard
+- Reduce sync frequency
+- Use incremental sync modes

--- a/airbyte/destinations/postgres.json
+++ b/airbyte/destinations/postgres.json
@@ -1,0 +1,21 @@
+{
+  "destinationType": "postgres",
+  "name": "dest_postgres_raw",
+  "config": {
+    "host": "postgres.eleduck-analytics.svc.cluster.local",
+    "port": 5432,
+    "database": "analytics",
+    "schema": "raw",
+    "username": "${POSTGRES_USER}",
+    "password": "${POSTGRES_PASSWORD}",
+    "ssl_mode": {
+      "mode": "disable"
+    },
+    "tunnel_method": {
+      "tunnel_method": "NO_TUNNEL"
+    },
+    "raw_data_schema": "raw",
+    "default_normalization": true
+  },
+  "notes": "All sources write to this destination in the 'raw' schema."
+}

--- a/airbyte/sources/github.json
+++ b/airbyte/sources/github.json
@@ -1,0 +1,29 @@
+{
+  "sourceType": "github",
+  "name": "src_github",
+  "config": {
+    "credentials": {
+      "personal_access_token": "${GITHUB_PAT}"
+    },
+    "repositories": [
+      "Soypete/*"
+    ],
+    "start_date": "2020-01-01T00:00:00Z"
+  },
+  "streams": [
+    "repositories",
+    "commits",
+    "pull_requests",
+    "issues",
+    "stargazers",
+    "collaborators",
+    "deployments",
+    "workflows",
+    "workflow_runs"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "PAT needs repo, read:org, read:user scopes."
+}

--- a/airbyte/sources/linkedin.json
+++ b/airbyte/sources/linkedin.json
@@ -1,0 +1,24 @@
+{
+  "sourceType": "linkedin-pages",
+  "name": "src_linkedin",
+  "config": {
+    "credentials": {
+      "auth_type": "oauth2.0",
+      "client_id": "${LINKEDIN_CLIENT_ID}",
+      "client_secret": "${LINKEDIN_CLIENT_SECRET}",
+      "refresh_token": "${LINKEDIN_REFRESH_TOKEN}"
+    },
+    "org_id": "${LINKEDIN_ORGANIZATION_ID}"
+  },
+  "streams": [
+    "share_statistics",
+    "follower_statistics",
+    "page_statistics",
+    "total_follower_counts"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Requires LinkedIn Company Page admin access."
+}

--- a/airbyte/sources/notion.json
+++ b/airbyte/sources/notion.json
@@ -1,0 +1,22 @@
+{
+  "sourceType": "notion",
+  "name": "src_notion",
+  "config": {
+    "credentials": {
+      "auth_type": "token",
+      "token": "${NOTION_API_TOKEN}"
+    },
+    "start_date": "2020-01-01T00:00:00Z"
+  },
+  "streams": [
+    "pages",
+    "databases",
+    "blocks",
+    "users"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Integration needs access to relevant databases/pages."
+}

--- a/airbyte/sources/stripe.json
+++ b/airbyte/sources/stripe.json
@@ -1,0 +1,25 @@
+{
+  "sourceType": "stripe",
+  "name": "src_stripe",
+  "config": {
+    "client_secret": "${STRIPE_SECRET_KEY}",
+    "account_id": "${STRIPE_ACCOUNT_ID}",
+    "start_date": "2020-01-01T00:00:00Z"
+  },
+  "streams": [
+    "charges",
+    "customers",
+    "invoices",
+    "subscriptions",
+    "products",
+    "prices",
+    "payment_intents",
+    "balance_transactions",
+    "payouts"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Use restricted key with read-only access."
+}

--- a/airbyte/sources/twitch.json
+++ b/airbyte/sources/twitch.json
@@ -1,0 +1,22 @@
+{
+  "sourceType": "twitch",
+  "name": "src_twitch",
+  "config": {
+    "client_id": "${TWITCH_CLIENT_ID}",
+    "client_secret": "${TWITCH_CLIENT_SECRET}",
+    "user_id": "${TWITCH_USER_ID}"
+  },
+  "streams": [
+    "streams",
+    "followers",
+    "videos",
+    "clips",
+    "subscriptions",
+    "channel_points"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Sync daily at 2am UTC. Uses Twitch Helix API."
+}

--- a/airbyte/sources/twitter.json
+++ b/airbyte/sources/twitter.json
@@ -1,0 +1,20 @@
+{
+  "sourceType": "twitter",
+  "name": "src_twitter",
+  "config": {
+    "api_key": "${TWITTER_API_KEY}",
+    "api_secret": "${TWITTER_API_SECRET}",
+    "access_token": "${TWITTER_ACCESS_TOKEN}",
+    "access_token_secret": "${TWITTER_ACCESS_TOKEN_SECRET}"
+  },
+  "streams": [
+    "tweets",
+    "users",
+    "user_metrics"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Twitter API access requires paid tier ($100/mo minimum). Consider X API alternatives."
+}

--- a/airbyte/sources/youtube.json
+++ b/airbyte/sources/youtube.json
@@ -1,0 +1,24 @@
+{
+  "sourceType": "youtube-analytics",
+  "name": "src_youtube",
+  "config": {
+    "credentials": {
+      "auth_type": "oauth2.0",
+      "client_id": "${YOUTUBE_CLIENT_ID}",
+      "client_secret": "${YOUTUBE_CLIENT_SECRET}",
+      "refresh_token": "${YOUTUBE_REFRESH_TOKEN}"
+    }
+  },
+  "streams": [
+    "channel_basic_a2",
+    "channel_combined_a2",
+    "channel_demographics_a1",
+    "videos",
+    "playlist_reports"
+  ],
+  "syncSchedule": {
+    "scheduleType": "cron",
+    "cronExpression": "0 2 * * *"
+  },
+  "notes": "Sync daily at 2am UTC. Uses YouTube Analytics API v2."
+}

--- a/k8s/1password/onepassworditem-airbyte-github.yaml
+++ b/k8s/1password/onepassworditem-airbyte-github.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-github
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-github"

--- a/k8s/1password/onepassworditem-airbyte-linkedin.yaml
+++ b/k8s/1password/onepassworditem-airbyte-linkedin.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-linkedin
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-linkedin"

--- a/k8s/1password/onepassworditem-airbyte-notion.yaml
+++ b/k8s/1password/onepassworditem-airbyte-notion.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-notion
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-notion"

--- a/k8s/1password/onepassworditem-airbyte-stripe.yaml
+++ b/k8s/1password/onepassworditem-airbyte-stripe.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-stripe
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-stripe"

--- a/k8s/1password/onepassworditem-airbyte-twitch.yaml
+++ b/k8s/1password/onepassworditem-airbyte-twitch.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-twitch
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-twitch"

--- a/k8s/1password/onepassworditem-airbyte-twitter.yaml
+++ b/k8s/1password/onepassworditem-airbyte-twitter.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-twitter
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-twitter"

--- a/k8s/1password/onepassworditem-airbyte-youtube.yaml
+++ b/k8s/1password/onepassworditem-airbyte-youtube.yaml
@@ -1,0 +1,7 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: airbyte-youtube
+  namespace: eleduck-analytics
+spec:
+  itemPath: "vaults/SoypeteTech/items/airbyte-youtube"

--- a/k8s/1password/onepassworditem-airbyte.yaml
+++ b/k8s/1password/onepassworditem-airbyte.yaml
@@ -1,2 +1,0 @@
-# Airbyte source credentials - configured in Plan 2
-# Each source will have its own OnePasswordItem

--- a/k8s/airbyte/kustomization.yaml
+++ b/k8s/airbyte/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: eleduck-analytics
+
+# Note: Airbyte is deployed via Helm, not kustomize directly
+# This kustomization handles supplementary resources
+
+resources:
+  - storage.yaml
+
+configMapGenerator:
+  - name: airbyte-config
+    literals:
+      - AIRBYTE_DESTINATION_HOST=postgres.eleduck-analytics.svc.cluster.local
+      - AIRBYTE_DESTINATION_PORT=5432
+      - AIRBYTE_DESTINATION_DATABASE=analytics
+      - AIRBYTE_DESTINATION_SCHEMA=raw

--- a/k8s/airbyte/storage.yaml
+++ b/k8s/airbyte/storage.yaml
@@ -1,0 +1,24 @@
+# PVC for Airbyte logs and state
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airbyte-data
+  namespace: eleduck-analytics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airbyte-logs
+  namespace: eleduck-analytics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/airbyte/values.yaml
+++ b/k8s/airbyte/values.yaml
@@ -1,0 +1,98 @@
+# Airbyte OSS Helm Chart Values
+# Chart: https://github.com/airbytehq/airbyte-platform-charts
+
+global:
+  serviceAccountName: airbyte
+  deploymentMode: "oss"
+  edition: "community"
+
+  # Use external PostgreSQL (from Plan 1)
+  database:
+    type: external
+    host: postgres.eleduck-analytics.svc.cluster.local
+    port: 5432
+    database: airbyte_internal
+    secretName: postgres-credentials
+    secretUserKey: username
+    secretPasswordKey: password
+
+# Disable internal PostgreSQL
+postgresql:
+  enabled: false
+
+# Disable internal Minio - use local storage
+minio:
+  enabled: false
+
+# Webapp configuration
+webapp:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+# Server configuration
+server:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+# Worker configuration
+worker:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+# Temporal configuration
+temporal:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+# Pod configuration
+pod:
+  tolerations: []
+  nodeSelector: {}
+
+# Logging
+airbyte-bootloader:
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "250m"
+
+# Connector builder (optional, can disable to save resources)
+connector-builder-server:
+  enabled: false
+
+# Keycloak (disable - using Tailscale for auth)
+keycloak:
+  enabled: false
+
+keycloak-setup:
+  enabled: false

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -6,4 +6,12 @@ namespace: eleduck-analytics
 resources:
   - namespace.yaml
   - 1password/onepassworditem-postgres.yaml
+  - 1password/onepassworditem-airbyte-youtube.yaml
+  - 1password/onepassworditem-airbyte-twitch.yaml
+  - 1password/onepassworditem-airbyte-twitter.yaml
+  - 1password/onepassworditem-airbyte-linkedin.yaml
+  - 1password/onepassworditem-airbyte-github.yaml
+  - 1password/onepassworditem-airbyte-stripe.yaml
+  - 1password/onepassworditem-airbyte-notion.yaml
   - postgres/
+  - airbyte/


### PR DESCRIPTION
- Add Airbyte Helm values and Kubernetes resources
- Add 1Password items for 7 source credentials (YouTube, Twitch, Twitter, LinkedIn, GitHub, Stripe, Notion)
- Add source configuration templates in airbyte/sources/
- Add PostgreSQL destination configuration
- Add Airbyte documentation with setup instructions
- Add Makefile targets for Airbyte operations