### PR TITLE
feat: add podcast analytics pipeline with Spotify + YouTube integration

### DIFF
--- a/airbyte/connections/spotify-to-postgres.yaml
+++ b/airbyte/connections/spotify-to-postgres.yaml
@@ -1,0 +1,86 @@
+# Airbyte Connection: Spotify for Creators → PostgreSQL
+# Syncs podcast data from Spotify to raw schema
+
+name: Spotify to PostgreSQL
+sourceId: spotify-for-creators
+destinationId: postgres-duckdb
+
+status: active
+
+syncCatalog:
+  streams:
+    - stream:
+        name: episodes
+        namespace: spotify
+        jsonSchema: {}
+        supportedSyncModes:
+          - full_refresh
+        sourceDefinedPrimaryKey:
+          - - id
+      config:
+        syncMode: full_refresh
+        destinationSyncMode: overwrite
+        primaryKey:
+          - - id
+        aliasName: spotify_episodes
+        selected: true
+
+    - stream:
+        name: episode_performance
+        namespace: spotify
+        jsonSchema: {}
+        supportedSyncModes:
+          - incremental
+        sourceDefinedCursor: true
+        defaultCursorField:
+          - date
+        sourceDefinedPrimaryKey:
+          - - episode_id
+          - - date
+      config:
+        syncMode: incremental
+        destinationSyncMode: append
+        cursorField:
+          - date
+        primaryKey:
+          - - episode_id
+          - - date
+        aliasName: spotify_episode_performance
+        selected: true
+
+    - stream:
+        name: show_stats
+        namespace: spotify
+        jsonSchema: {}
+        supportedSyncModes:
+          - incremental
+        sourceDefinedCursor: true
+        defaultCursorField:
+          - date
+        sourceDefinedPrimaryKey:
+          - - date
+      config:
+        syncMode: incremental
+        destinationSyncMode: append
+        cursorField:
+          - date
+        primaryKey:
+          - - date
+        aliasName: spotify_show_stats
+        selected: true
+
+scheduleType: cron
+scheduleData:
+  cron:
+    cronExpression: "0 6 * * *"
+    cronTimeZone: UTC
+
+namespaceDefinition: destination
+namespaceFormat: raw
+prefix: ""
+
+resourceRequirements:
+  cpu_request: "0.5"
+  cpu_limit: "1"
+  memory_request: "512Mi"
+  memory_limit: "1Gi"

--- a/airbyte/connections/youtube-to-postgres.yaml
+++ b/airbyte/connections/youtube-to-postgres.yaml
@@ -1,0 +1,65 @@
+# Airbyte Connection: YouTube Analytics → PostgreSQL
+# Syncs video analytics from YouTube to raw schema
+
+name: YouTube to PostgreSQL
+sourceId: youtube-analytics
+destinationId: postgres-duckdb
+
+status: active
+
+syncCatalog:
+  streams:
+    - stream:
+        name: videos
+        namespace: youtube
+        jsonSchema: {}
+        supportedSyncModes:
+          - full_refresh
+        sourceDefinedPrimaryKey:
+          - - id
+      config:
+        syncMode: full_refresh
+        destinationSyncMode: overwrite
+        primaryKey:
+          - - id
+        aliasName: youtube_videos
+        selected: true
+
+    - stream:
+        name: daily_stats
+        namespace: youtube
+        jsonSchema: {}
+        supportedSyncModes:
+          - incremental
+        sourceDefinedCursor: true
+        defaultCursorField:
+          - date
+        sourceDefinedPrimaryKey:
+          - - video_id
+          - - date
+      config:
+        syncMode: incremental
+        destinationSyncMode: append
+        cursorField:
+          - date
+        primaryKey:
+          - - video_id
+          - - date
+        aliasName: youtube_daily_stats
+        selected: true
+
+scheduleType: cron
+scheduleData:
+  cron:
+    cronExpression: "0 7 * * *"
+    cronTimeZone: UTC
+
+namespaceDefinition: destination
+namespaceFormat: raw
+prefix: ""
+
+resourceRequirements:
+  cpu_request: "0.5"
+  cpu_limit: "1"
+  memory_request: "512Mi"
+  memory_limit: "1Gi"

--- a/airbyte/destinations/postgres-duckdb.yaml
+++ b/airbyte/destinations/postgres-duckdb.yaml
@@ -1,0 +1,32 @@
+# Airbyte Destination Configuration for PostgreSQL + DuckDB
+# Data lands in the 'raw' schema for DBT transformation
+#
+# Connection details are injected from 1Password secret
+
+destinationDefinitionId: postgres
+name: PostgreSQL DuckDB - Podcast Analytics
+connectionConfiguration:
+  # Connection details - injected from 1Password
+  host: "${POSTGRES_HOST}"
+  port: 5432
+  database: "${POSTGRES_DATABASE}"
+  username: "${POSTGRES_USER}"
+  password: "${POSTGRES_PASSWORD}"
+
+  # Schema configuration
+  schema: raw
+
+  # SSL configuration (for production)
+  ssl_mode:
+    mode: prefer
+
+  # Connection pool settings
+  jdbc_url_params: ""
+
+# Normalization settings
+normalization:
+  option: basic
+
+# Namespace configuration
+namespaceDefinition: source
+namespaceFormat: "${SOURCE_NAMESPACE}"

--- a/airbyte/sources/spotify-for-creators.yaml
+++ b/airbyte/sources/spotify-for-creators.yaml
@@ -1,0 +1,105 @@
+# Airbyte Source Configuration for Spotify for Creators
+# Note: Spotify for Creators uses OAuth2 authentication
+#
+# Prerequisites:
+# 1. Register an app at https://developer.spotify.com/dashboard
+# 2. Configure OAuth2 redirect URI
+# 3. Request access to Spotify for Creators API (requires approval)
+# 4. Store credentials in 1Password (see k8s/1password/onepassworditem-spotify.yaml)
+
+sourceDefinitionId: custom-spotify-for-creators
+name: Spotify for Creators - SoypeteTech Podcast
+connectionConfiguration:
+  # OAuth2 credentials - injected from 1Password
+  client_id: "${SPOTIFY_CLIENT_ID}"
+  client_secret: "${SPOTIFY_CLIENT_SECRET}"
+  refresh_token: "${SPOTIFY_REFRESH_TOKEN}"
+
+  # Show configuration
+  show_id: "${SPOTIFY_SHOW_ID}"
+
+  # Date range for historical data
+  start_date: "2020-01-01"
+
+  # API configuration
+  api_base_url: "https://generic.wg.spotify.com/podcasters"
+
+streams:
+  - name: episodes
+    sync_mode: full_refresh
+    destination_sync_mode: overwrite
+    cursor_field: []
+    primary_key:
+      - id
+    json_schema:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        release_date:
+          type: string
+          format: date
+        duration_ms:
+          type: integer
+        explicit:
+          type: boolean
+        uri:
+          type: string
+        external_urls:
+          type: object
+          properties:
+            spotify:
+              type: string
+
+  - name: episode_performance
+    sync_mode: incremental
+    destination_sync_mode: append
+    cursor_field:
+      - date
+    primary_key:
+      - episode_id
+      - date
+    json_schema:
+      type: object
+      properties:
+        episode_id:
+          type: string
+        date:
+          type: string
+          format: date
+        starts:
+          type: integer
+        streams:
+          type: integer
+        listeners:
+          type: integer
+        avg_listen_seconds:
+          type: number
+
+  - name: show_stats
+    sync_mode: incremental
+    destination_sync_mode: append
+    cursor_field:
+      - date
+    primary_key:
+      - date
+    json_schema:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        total_streams:
+          type: integer
+        followers:
+          type: integer
+        total_listeners:
+          type: integer
+
+schedule:
+  scheduleType: cron
+  cronExpression: "0 6 * * *"  # Daily at 6 AM UTC

--- a/airbyte/sources/youtube-analytics.yaml
+++ b/airbyte/sources/youtube-analytics.yaml
@@ -1,0 +1,88 @@
+# Airbyte Source Configuration for YouTube Analytics
+# Uses the official Airbyte YouTube Analytics connector
+#
+# Prerequisites:
+# 1. Create OAuth2 credentials in Google Cloud Console
+# 2. Enable YouTube Analytics API and YouTube Data API v3
+# 3. Configure OAuth2 consent screen
+# 4. Store credentials in 1Password (see k8s/1password/onepassworditem-youtube.yaml)
+
+sourceDefinitionId: youtube-analytics
+name: YouTube Analytics - SoypeteTech Channel
+connectionConfiguration:
+  # OAuth2 credentials - injected from 1Password
+  credentials:
+    client_id: "${YOUTUBE_CLIENT_ID}"
+    client_secret: "${YOUTUBE_CLIENT_SECRET}"
+    refresh_token: "${YOUTUBE_REFRESH_TOKEN}"
+
+  # Channel configuration
+  channel_id: "${YOUTUBE_CHANNEL_ID}"
+
+  # Date range for historical data
+  start_date: "2020-01-01"
+
+streams:
+  - name: videos
+    sync_mode: full_refresh
+    destination_sync_mode: overwrite
+    cursor_field: []
+    primary_key:
+      - id
+    json_schema:
+      type: object
+      properties:
+        id:
+          type: string
+        snippet:
+          type: object
+          properties:
+            title:
+              type: string
+            description:
+              type: string
+            publishedAt:
+              type: string
+              format: date-time
+            channelId:
+              type: string
+            channelTitle:
+              type: string
+        contentDetails:
+          type: object
+          properties:
+            duration:
+              type: string
+            definition:
+              type: string
+
+  - name: daily_stats
+    sync_mode: incremental
+    destination_sync_mode: append
+    cursor_field:
+      - date
+    primary_key:
+      - video_id
+      - date
+    json_schema:
+      type: object
+      properties:
+        video_id:
+          type: string
+        date:
+          type: string
+          format: date
+        views:
+          type: integer
+        watch_time_minutes:
+          type: number
+        average_view_duration:
+          type: number
+        likes:
+          type: integer
+        comments:
+          type: integer
+
+schedule:
+  scheduleType: cron
+  cronExpression: "0 7 * * *"  # Daily at 7 AM UTC (after Spotify sync)

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,38 @@
+name: 'podcast_analytics'
+version: '1.0.0'
+config-version: 2
+
+profile: 'podcast_analytics'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+clean-targets:
+  - "target"
+  - "dbt_packages"
+
+models:
+  podcast_analytics:
+    staging:
+      +schema: staging
+      +materialized: view
+      spotify:
+        +tags: ['spotify', 'staging']
+      youtube:
+        +tags: ['youtube', 'staging']
+    intermediate:
+      +schema: staging
+      +materialized: view
+      +tags: ['intermediate']
+    marts:
+      +schema: analytics
+      +materialized: table
+      +tags: ['marts']
+
+seeds:
+  podcast_analytics:
+    +schema: staging

--- a/dbt/macros/parse_youtube_duration.sql
+++ b/dbt/macros/parse_youtube_duration.sql
@@ -1,0 +1,29 @@
+{% macro parse_youtube_duration(duration_column) %}
+{#
+    Parses YouTube ISO 8601 duration format (PT#H#M#S) to seconds.
+    Examples:
+      - PT1H30M15S -> 5415 seconds
+      - PT30M -> 1800 seconds
+      - PT45S -> 45 seconds
+#}
+    coalesce(
+        (
+            -- Extract hours
+            coalesce(
+                (regexp_match({{ duration_column }}, 'PT(\d+)H'))[1]::int * 3600,
+                0
+            ) +
+            -- Extract minutes
+            coalesce(
+                (regexp_match({{ duration_column }}, '(\d+)M'))[1]::int * 60,
+                0
+            ) +
+            -- Extract seconds
+            coalesce(
+                (regexp_match({{ duration_column }}, '(\d+)S'))[1]::int,
+                0
+            )
+        ),
+        0
+    )
+{% endmacro %}

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: int_content_unified
+    description: >
+      Unified content model that joins Spotify episodes with YouTube videos
+      using the manual content mapping seed. This creates a single view of content
+      across both platforms for downstream analytics.
+    columns:
+      - name: content_id
+        description: "Unique identifier for the content piece across platforms"
+        tests:
+          - unique
+          - not_null
+      - name: episode_id
+        description: "Spotify episode ID (null if YouTube-only content)"
+      - name: video_id
+        description: "YouTube video ID (null if Spotify-only content)"
+      - name: title
+        description: "Content title (from Spotify if available, otherwise YouTube)"
+        tests:
+          - not_null
+      - name: published_date
+        description: "Publication date (earliest if different across platforms)"
+        tests:
+          - not_null
+      - name: duration_seconds
+        description: "Content duration in seconds"
+      - name: content_source
+        description: "Indicates platform availability: 'both_platforms', 'spotify_only', or 'youtube_only'"
+        tests:
+          - accepted_values:
+              values: ['both_platforms', 'spotify_only', 'youtube_only']

--- a/dbt/models/intermediate/int_content_unified.sql
+++ b/dbt/models/intermediate/int_content_unified.sql
@@ -1,0 +1,103 @@
+{{
+    config(
+        materialized='view',
+        tags=['intermediate']
+    )
+}}
+
+{#
+    This model unifies content from both Spotify (podcast episodes) and YouTube (videos)
+    using a manual mapping seed to link corresponding content across platforms.
+
+    The mapping allows us to track the same content piece across multiple distribution channels.
+#}
+
+with episodes as (
+    select * from {{ ref('stg_spotify__episodes') }}
+),
+
+videos as (
+    select * from {{ ref('stg_youtube__videos') }}
+),
+
+mapping as (
+    -- Manual mapping between episode_id and video_id
+    select * from {{ ref('seed_content_mapping') }}
+),
+
+-- Join episodes to mapping
+episode_content as (
+    select
+        m.content_id,
+        e.episode_id,
+        null::varchar as video_id,
+        e.title,
+        e.published_date,
+        e.duration_seconds,
+        'spotify_only' as content_source
+    from episodes e
+    left join mapping m on e.episode_id = m.episode_id
+    where m.video_id is null or m.video_id = ''
+),
+
+-- Join videos to mapping
+video_content as (
+    select
+        m.content_id,
+        null::varchar as episode_id,
+        v.video_id,
+        v.title,
+        v.published_date,
+        v.duration_seconds,
+        'youtube_only' as content_source
+    from videos v
+    left join mapping m on v.video_id = m.video_id
+    where m.episode_id is null or m.episode_id = ''
+),
+
+-- Unified content with both platforms
+mapped_content as (
+    select
+        m.content_id,
+        e.episode_id,
+        v.video_id,
+        coalesce(e.title, v.title) as title,
+        coalesce(e.published_date, v.published_date) as published_date,
+        coalesce(e.duration_seconds, v.duration_seconds) as duration_seconds,
+        case
+            when e.episode_id is not null and v.video_id is not null then 'both_platforms'
+            when e.episode_id is not null then 'spotify_only'
+            when v.video_id is not null then 'youtube_only'
+        end as content_source
+    from mapping m
+    left join episodes e on m.episode_id = e.episode_id
+    left join videos v on m.video_id = v.video_id
+    where m.content_id is not null
+),
+
+-- Combine all content
+unified as (
+    select * from mapped_content
+    union all
+    select * from episode_content where content_id is null
+    union all
+    select * from video_content where content_id is null
+),
+
+-- Generate content_id for unmapped content
+final as (
+    select
+        coalesce(
+            content_id,
+            'ep-' || coalesce(episode_id, video_id)
+        ) as content_id,
+        episode_id,
+        video_id,
+        title,
+        published_date,
+        duration_seconds,
+        content_source
+    from unified
+)
+
+select * from final

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -1,0 +1,111 @@
+version: 2
+
+models:
+  - name: mart_content_performance
+    description: >
+      Content-level performance aggregations combining Spotify and YouTube metrics.
+      Each row represents a unique content piece with total metrics across platforms.
+    columns:
+      - name: content_id
+        description: "Unique identifier for the content"
+        tests:
+          - unique
+          - not_null
+      - name: title
+        description: "Content title"
+      - name: published_date
+        description: "Publication date"
+      - name: duration_seconds
+        description: "Content duration in seconds"
+      - name: content_source
+        description: "Platform availability indicator"
+      - name: episode_id
+        description: "Spotify episode ID"
+      - name: video_id
+        description: "YouTube video ID"
+      - name: total_streams
+        description: "Total Spotify streams"
+      - name: total_starts
+        description: "Total Spotify episode starts"
+      - name: total_unique_listeners
+        description: "Total unique Spotify listeners"
+      - name: avg_listen_seconds
+        description: "Average listen time on Spotify"
+      - name: total_views
+        description: "Total YouTube views"
+      - name: total_watch_minutes
+        description: "Total YouTube watch time in minutes"
+      - name: total_likes
+        description: "Total YouTube likes"
+      - name: total_comments
+        description: "Total YouTube comments"
+      - name: avg_view_seconds
+        description: "Average view duration on YouTube"
+      - name: total_consumption
+        description: "Combined streams + views across platforms"
+      - name: youtube_like_rate
+        description: "Likes per view on YouTube"
+      - name: spotify_completion_rate
+        description: "Streams per start on Spotify"
+
+  - name: mart_daily_metrics
+    description: >
+      Daily time-series metrics for trend analysis and dashboards.
+      One row per day with aggregated metrics from both platforms.
+    columns:
+      - name: metric_date
+        description: "Date of the metrics"
+        tests:
+          - unique
+          - not_null
+      - name: spotify_streams
+        description: "Total Spotify streams on this date"
+      - name: spotify_starts
+        description: "Total Spotify starts on this date"
+      - name: spotify_listeners
+        description: "Unique Spotify listeners on this date"
+      - name: youtube_views
+        description: "Total YouTube views on this date"
+      - name: youtube_watch_minutes
+        description: "Total YouTube watch time in minutes"
+      - name: youtube_likes
+        description: "YouTube likes on this date"
+      - name: youtube_comments
+        description: "YouTube comments on this date"
+      - name: total_consumption
+        description: "Combined streams + views"
+      - name: day_of_week
+        description: "Day of week number (0=Sunday)"
+      - name: day_name
+        description: "Day of week name"
+
+  - name: mart_platform_comparison
+    description: >
+      Platform-level summary for comparing Spotify vs YouTube performance.
+      One row per platform with aggregate metrics.
+    columns:
+      - name: platform
+        description: "Platform name (spotify or youtube)"
+        tests:
+          - unique
+          - not_null
+          - accepted_values:
+              values: ['spotify', 'youtube']
+      - name: total_consumption
+        description: "Total streams/views for the platform"
+      - name: total_starts
+        description: "Total starts (Spotify only)"
+      - name: total_reach
+        description: "Total unique listeners/viewers"
+      - name: content_count
+        description: "Number of content pieces"
+      - name: first_date
+        description: "First date with metrics"
+      - name: last_date
+        description: "Most recent date with metrics"
+      - name: days_active
+        description: "Number of days with activity"
+      - name: avg_daily_consumption
+        description: "Average daily streams/views"
+      - name: followers
+        description: "Follower count (Spotify only)"

--- a/dbt/models/marts/mart_content_performance.sql
+++ b/dbt/models/marts/mart_content_performance.sql
@@ -1,0 +1,87 @@
+{{
+    config(
+        materialized='table',
+        tags=['marts']
+    )
+}}
+
+{#
+    Content Performance Mart
+    Aggregates total performance metrics for each content piece across Spotify and YouTube.
+    Used for top-level content rankings and performance comparisons.
+#}
+
+with content as (
+    select * from {{ ref('int_content_unified') }}
+),
+
+-- Aggregate Spotify streams per episode
+spotify_metrics as (
+    select
+        episode_id,
+        sum(streams) as total_streams,
+        sum(starts) as total_starts,
+        sum(unique_listeners) as total_unique_listeners,
+        avg(avg_listen_seconds) as avg_listen_seconds
+    from {{ ref('stg_spotify__daily_performance') }}
+    group by 1
+),
+
+-- Aggregate YouTube metrics per video
+youtube_metrics as (
+    select
+        video_id,
+        sum(views) as total_views,
+        sum(watch_time_minutes) as total_watch_minutes,
+        sum(likes) as total_likes,
+        sum(comments) as total_comments,
+        avg(avg_view_seconds) as avg_view_seconds
+    from {{ ref('stg_youtube__daily_stats') }}
+    group by 1
+),
+
+final as (
+    select
+        c.content_id,
+        c.title,
+        c.published_date,
+        c.duration_seconds,
+        c.content_source,
+        c.episode_id,
+        c.video_id,
+
+        -- Spotify metrics
+        coalesce(s.total_streams, 0) as total_streams,
+        coalesce(s.total_starts, 0) as total_starts,
+        coalesce(s.total_unique_listeners, 0) as total_unique_listeners,
+        s.avg_listen_seconds,
+
+        -- YouTube metrics
+        coalesce(y.total_views, 0) as total_views,
+        coalesce(y.total_watch_minutes, 0) as total_watch_minutes,
+        coalesce(y.total_likes, 0) as total_likes,
+        coalesce(y.total_comments, 0) as total_comments,
+        y.avg_view_seconds,
+
+        -- Combined metrics
+        coalesce(s.total_streams, 0) + coalesce(y.total_views, 0) as total_consumption,
+
+        -- Calculated engagement rates
+        case
+            when y.total_views > 0 then y.total_likes::decimal / y.total_views
+            else 0
+        end as youtube_like_rate,
+
+        case
+            when s.total_starts > 0 then s.total_streams::decimal / s.total_starts
+            else 0
+        end as spotify_completion_rate,
+
+        current_timestamp as _dbt_updated_at
+
+    from content c
+    left join spotify_metrics s on c.episode_id = s.episode_id
+    left join youtube_metrics y on c.video_id = y.video_id
+)
+
+select * from final

--- a/dbt/models/marts/mart_daily_metrics.sql
+++ b/dbt/models/marts/mart_daily_metrics.sql
@@ -1,0 +1,72 @@
+{{
+    config(
+        materialized='table',
+        tags=['marts']
+    )
+}}
+
+{#
+    Daily Metrics Mart
+    Time-series aggregation of daily metrics across both platforms.
+    Used for trend analysis and daily performance dashboards.
+#}
+
+with spotify_daily as (
+    select
+        metric_date,
+        sum(streams) as streams,
+        sum(starts) as starts,
+        sum(unique_listeners) as listeners
+    from {{ ref('stg_spotify__daily_performance') }}
+    group by 1
+),
+
+youtube_daily as (
+    select
+        metric_date,
+        sum(views) as views,
+        sum(watch_time_minutes) as watch_minutes,
+        sum(likes) as likes,
+        sum(comments) as comments
+    from {{ ref('stg_youtube__daily_stats') }}
+    group by 1
+),
+
+-- Generate a complete date spine from both sources
+date_spine as (
+    select distinct metric_date from spotify_daily
+    union
+    select distinct metric_date from youtube_daily
+),
+
+final as (
+    select
+        d.metric_date,
+
+        -- Spotify metrics
+        coalesce(s.streams, 0) as spotify_streams,
+        coalesce(s.starts, 0) as spotify_starts,
+        coalesce(s.listeners, 0) as spotify_listeners,
+
+        -- YouTube metrics
+        coalesce(y.views, 0) as youtube_views,
+        coalesce(y.watch_minutes, 0) as youtube_watch_minutes,
+        coalesce(y.likes, 0) as youtube_likes,
+        coalesce(y.comments, 0) as youtube_comments,
+
+        -- Combined metrics
+        coalesce(s.streams, 0) + coalesce(y.views, 0) as total_consumption,
+
+        -- Day of week for analysis
+        extract(dow from d.metric_date) as day_of_week,
+        to_char(d.metric_date, 'Day') as day_name,
+
+        current_timestamp as _dbt_updated_at
+
+    from date_spine d
+    left join spotify_daily s on d.metric_date = s.metric_date
+    left join youtube_daily y on d.metric_date = y.metric_date
+)
+
+select * from final
+order by metric_date

--- a/dbt/models/marts/mart_platform_comparison.sql
+++ b/dbt/models/marts/mart_platform_comparison.sql
@@ -1,0 +1,83 @@
+{{
+    config(
+        materialized='table',
+        tags=['marts']
+    )
+}}
+
+{#
+    Platform Comparison Mart
+    Compares performance metrics between Spotify and YouTube.
+    Used for platform-level analysis and audience insights.
+#}
+
+with spotify_totals as (
+    select
+        'spotify' as platform,
+        sum(streams) as total_consumption,
+        sum(starts) as total_starts,
+        sum(unique_listeners) as total_reach,
+        count(distinct episode_id) as content_count,
+        min(metric_date) as first_date,
+        max(metric_date) as last_date
+    from {{ ref('stg_spotify__daily_performance') }}
+),
+
+youtube_totals as (
+    select
+        'youtube' as platform,
+        sum(views) as total_consumption,
+        null::bigint as total_starts,
+        null::bigint as total_reach,
+        count(distinct video_id) as content_count,
+        min(metric_date) as first_date,
+        max(metric_date) as last_date
+    from {{ ref('stg_youtube__daily_stats') }}
+),
+
+-- Get show-level stats
+spotify_show as (
+    select
+        max(followers) as followers,
+        max(total_streams) as cumulative_streams
+    from {{ ref('stg_spotify__show_stats') }}
+),
+
+combined as (
+    select * from spotify_totals
+    union all
+    select * from youtube_totals
+),
+
+final as (
+    select
+        c.platform,
+        c.total_consumption,
+        c.total_starts,
+        c.total_reach,
+        c.content_count,
+        c.first_date,
+        c.last_date,
+
+        -- Calculate days active
+        c.last_date - c.first_date + 1 as days_active,
+
+        -- Daily average consumption
+        case
+            when c.last_date - c.first_date + 1 > 0
+            then c.total_consumption::decimal / (c.last_date - c.first_date + 1)
+            else 0
+        end as avg_daily_consumption,
+
+        -- Spotify-specific: followers from show stats
+        case
+            when c.platform = 'spotify' then (select followers from spotify_show)
+            else null
+        end as followers,
+
+        current_timestamp as _dbt_updated_at
+
+    from combined c
+)
+
+select * from final

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -1,0 +1,98 @@
+version: 2
+
+sources:
+  - name: raw_spotify
+    description: "Raw data from Spotify for Creators (formerly Spotify for Podcasters) via Airbyte"
+    database: "{{ env_var('DBT_POSTGRES_DATABASE', 'eleduck') }}"
+    schema: raw
+    tables:
+      - name: spotify_episodes
+        description: "Episode metadata from Spotify for Creators API"
+        columns:
+          - name: id
+            description: "Unique Spotify episode URI/ID"
+            tests:
+              - unique
+              - not_null
+          - name: name
+            description: "Episode title"
+          - name: release_date
+            description: "Episode release date"
+          - name: duration_ms
+            description: "Duration in milliseconds"
+          - name: description
+            description: "Episode description"
+
+      - name: spotify_episode_performance
+        description: "Daily performance metrics per episode from Spotify Analytics"
+        columns:
+          - name: episode_id
+            description: "Foreign key to spotify_episodes"
+            tests:
+              - not_null
+          - name: date
+            description: "Date of the metric"
+            tests:
+              - not_null
+          - name: starts
+            description: "Number of times episode was started"
+          - name: streams
+            description: "Number of streams (plays over 60 seconds)"
+          - name: listeners
+            description: "Unique listeners count"
+          - name: avg_listen_seconds
+            description: "Average listen time in seconds"
+
+      - name: spotify_show_stats
+        description: "Show-level aggregate statistics from Spotify"
+        columns:
+          - name: date
+            description: "Date of the stats snapshot"
+            tests:
+              - not_null
+          - name: total_streams
+            description: "Cumulative total streams"
+          - name: followers
+            description: "Current follower count"
+          - name: total_listeners
+            description: "Cumulative unique listeners"
+
+  - name: raw_youtube
+    description: "Raw data from YouTube Analytics and Data APIs via Airbyte"
+    database: "{{ env_var('DBT_POSTGRES_DATABASE', 'eleduck') }}"
+    schema: raw
+    tables:
+      - name: youtube_videos
+        description: "Video metadata from YouTube Data API videos.list"
+        columns:
+          - name: id
+            description: "YouTube video ID"
+            tests:
+              - unique
+              - not_null
+          - name: snippet
+            description: "JSONB containing video snippet (title, description, publishedAt)"
+          - name: content_details
+            description: "JSONB containing content details (duration, dimension)"
+
+      - name: youtube_daily_stats
+        description: "Daily video metrics from YouTube Analytics API"
+        columns:
+          - name: video_id
+            description: "Foreign key to youtube_videos"
+            tests:
+              - not_null
+          - name: date
+            description: "Date of the metric"
+            tests:
+              - not_null
+          - name: views
+            description: "Number of views on this date"
+          - name: watch_time_minutes
+            description: "Total watch time in minutes"
+          - name: average_view_duration
+            description: "Average view duration in seconds"
+          - name: likes
+            description: "Number of likes"
+          - name: comments
+            description: "Number of comments"

--- a/dbt/models/staging/spotify/_spotify__models.yml
+++ b/dbt/models/staging/spotify/_spotify__models.yml
@@ -1,0 +1,70 @@
+version: 2
+
+models:
+  - name: stg_spotify__episodes
+    description: "Staging model for Spotify for Creators podcast episodes"
+    columns:
+      - name: episode_id
+        description: "Unique Spotify episode identifier"
+        tests:
+          - unique
+          - not_null
+      - name: title
+        description: "Episode title"
+        tests:
+          - not_null
+      - name: published_date
+        description: "Date the episode was released"
+        tests:
+          - not_null
+      - name: duration_seconds
+        description: "Duration of the episode in seconds"
+      - name: description
+        description: "Episode description"
+      - name: is_explicit
+        description: "Whether the episode is marked as explicit"
+      - name: spotify_uri
+        description: "Spotify URI for the episode"
+      - name: spotify_url
+        description: "Direct URL to the episode on Spotify"
+
+  - name: stg_spotify__daily_performance
+    description: "Staging model for daily episode performance metrics from Spotify"
+    columns:
+      - name: episode_id
+        description: "Spotify episode identifier"
+        tests:
+          - not_null
+      - name: metric_date
+        description: "Date of the performance metric"
+        tests:
+          - not_null
+      - name: starts
+        description: "Number of times the episode was started"
+        tests:
+          - not_null
+      - name: streams
+        description: "Number of streams (plays over 60 seconds)"
+        tests:
+          - not_null
+      - name: unique_listeners
+        description: "Count of unique listeners"
+      - name: avg_listen_seconds
+        description: "Average listen time in seconds"
+      - name: stream_through_rate
+        description: "Calculated ratio of streams to starts (completion rate)"
+
+  - name: stg_spotify__show_stats
+    description: "Staging model for show-level aggregate statistics from Spotify"
+    columns:
+      - name: stats_date
+        description: "Date of the stats snapshot"
+        tests:
+          - unique
+          - not_null
+      - name: total_streams
+        description: "Cumulative total streams"
+      - name: followers
+        description: "Current follower count"
+      - name: total_listeners
+        description: "Cumulative unique listeners"

--- a/dbt/models/staging/spotify/stg_spotify__daily_performance.sql
+++ b/dbt/models/staging/spotify/stg_spotify__daily_performance.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized='view',
+        tags=['spotify', 'staging']
+    )
+}}
+
+with source as (
+    select * from {{ source('raw_spotify', 'spotify_episode_performance') }}
+),
+
+renamed as (
+    select
+        episode_id,
+        date::date as metric_date,
+        starts,
+        streams,
+        listeners as unique_listeners,
+        avg_listen_seconds,
+        -- Calculate completion-related metrics
+        case
+            when starts > 0 then streams::decimal / starts
+            else 0
+        end as stream_through_rate,
+        -- Metadata for tracking
+        current_timestamp as _dbt_loaded_at
+    from source
+)
+
+select * from renamed

--- a/dbt/models/staging/spotify/stg_spotify__episodes.sql
+++ b/dbt/models/staging/spotify/stg_spotify__episodes.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized='view',
+        tags=['spotify', 'staging']
+    )
+}}
+
+with source as (
+    select * from {{ source('raw_spotify', 'spotify_episodes') }}
+),
+
+renamed as (
+    select
+        id as episode_id,
+        name as title,
+        release_date::date as published_date,
+        -- Convert milliseconds to seconds
+        (duration_ms / 1000)::int as duration_seconds,
+        description,
+        explicit as is_explicit,
+        -- Spotify-specific fields
+        uri as spotify_uri,
+        external_urls->>'spotify' as spotify_url,
+        -- Metadata for tracking
+        current_timestamp as _dbt_loaded_at
+    from source
+)
+
+select * from renamed

--- a/dbt/models/staging/spotify/stg_spotify__show_stats.sql
+++ b/dbt/models/staging/spotify/stg_spotify__show_stats.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        materialized='view',
+        tags=['spotify', 'staging']
+    )
+}}
+
+with source as (
+    select * from {{ source('raw_spotify', 'spotify_show_stats') }}
+),
+
+renamed as (
+    select
+        date::date as stats_date,
+        total_streams,
+        followers,
+        total_listeners,
+        -- Metadata for tracking
+        current_timestamp as _dbt_loaded_at
+    from source
+)
+
+select * from renamed

--- a/dbt/models/staging/youtube/_youtube__models.yml
+++ b/dbt/models/staging/youtube/_youtube__models.yml
@@ -1,0 +1,55 @@
+version: 2
+
+models:
+  - name: stg_youtube__videos
+    description: "Staging model for YouTube video metadata"
+    columns:
+      - name: video_id
+        description: "Unique YouTube video identifier"
+        tests:
+          - unique
+          - not_null
+      - name: title
+        description: "Video title"
+        tests:
+          - not_null
+      - name: published_date
+        description: "Date the video was published"
+        tests:
+          - not_null
+      - name: description
+        description: "Video description text"
+      - name: channel_id
+        description: "YouTube channel ID"
+      - name: channel_title
+        description: "YouTube channel name"
+      - name: duration_seconds
+        description: "Duration of the video in seconds"
+      - name: video_definition
+        description: "Video quality definition (hd, sd)"
+
+  - name: stg_youtube__daily_stats
+    description: "Staging model for daily YouTube video metrics"
+    columns:
+      - name: video_id
+        description: "YouTube video identifier"
+        tests:
+          - not_null
+      - name: metric_date
+        description: "Date of the metrics"
+        tests:
+          - not_null
+      - name: views
+        description: "Number of views on this date"
+        tests:
+          - not_null
+      - name: watch_time_minutes
+        description: "Total watch time in minutes"
+      - name: avg_view_seconds
+        description: "Average view duration in seconds"
+      - name: likes
+        description: "Number of likes"
+      - name: comments
+        description: "Number of comments"
+      - name: minutes_per_view
+        description: "Calculated average minutes watched per view"

--- a/dbt/models/staging/youtube/stg_youtube__daily_stats.sql
+++ b/dbt/models/staging/youtube/stg_youtube__daily_stats.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized='view',
+        tags=['youtube', 'staging']
+    )
+}}
+
+with source as (
+    select * from {{ source('raw_youtube', 'youtube_daily_stats') }}
+),
+
+renamed as (
+    select
+        video_id,
+        date::date as metric_date,
+        views,
+        watch_time_minutes,
+        average_view_duration as avg_view_seconds,
+        likes,
+        comments,
+        -- Calculated metrics
+        case
+            when views > 0 then watch_time_minutes::decimal / views
+            else 0
+        end as minutes_per_view,
+        -- Metadata for tracking
+        current_timestamp as _dbt_loaded_at
+    from source
+)
+
+select * from renamed

--- a/dbt/models/staging/youtube/stg_youtube__videos.sql
+++ b/dbt/models/staging/youtube/stg_youtube__videos.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        materialized='view',
+        tags=['youtube', 'staging']
+    )
+}}
+
+with source as (
+    select * from {{ source('raw_youtube', 'youtube_videos') }}
+),
+
+renamed as (
+    select
+        id as video_id,
+        snippet->>'title' as title,
+        (snippet->>'publishedAt')::date as published_date,
+        snippet->>'description' as description,
+        snippet->>'channelId' as channel_id,
+        snippet->>'channelTitle' as channel_title,
+        -- Parse ISO 8601 duration to seconds (PT#H#M#S format)
+        {{ parse_youtube_duration("content_details->>'duration'") }} as duration_seconds,
+        content_details->>'definition' as video_definition,
+        -- Metadata for tracking
+        current_timestamp as _dbt_loaded_at
+    from source
+)
+
+select * from renamed

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,26 @@
+# DBT profiles for podcast analytics pipeline
+# Note: This file uses environment variables for sensitive values
+# In production, credentials are injected via 1Password operator
+
+podcast_analytics:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DBT_POSTGRES_HOST', 'localhost') }}"
+      port: "{{ env_var('DBT_POSTGRES_PORT', '5432') | int }}"
+      user: "{{ env_var('DBT_POSTGRES_USER', 'postgres') }}"
+      password: "{{ env_var('DBT_POSTGRES_PASSWORD', '') }}"
+      dbname: "{{ env_var('DBT_POSTGRES_DATABASE', 'eleduck') }}"
+      schema: raw
+      threads: 4
+
+    prod:
+      type: postgres
+      host: "{{ env_var('DBT_POSTGRES_HOST') }}"
+      port: "{{ env_var('DBT_POSTGRES_PORT', '5432') | int }}"
+      user: "{{ env_var('DBT_POSTGRES_USER') }}"
+      password: "{{ env_var('DBT_POSTGRES_PASSWORD') }}"
+      dbname: "{{ env_var('DBT_POSTGRES_DATABASE') }}"
+      schema: raw
+      threads: 8

--- a/dbt/seeds/_seeds.yml
+++ b/dbt/seeds/_seeds.yml
@@ -1,0 +1,32 @@
+version: 2
+
+seeds:
+  - name: seed_content_mapping
+    description: >
+      Manual mapping between Transistor episode IDs and YouTube video IDs.
+      This allows tracking the same content piece across multiple platforms.
+
+      To add a mapping, add a row with:
+      - content_id: A unique identifier for the content (e.g., 'ep-001')
+      - episode_id: The Transistor episode ID
+      - video_id: The YouTube video ID
+
+      Example:
+        content_id,episode_id,video_id
+        ep-001,abc123,dQw4w9WgXcQ
+        ep-002,def456,xvFZjo5PgG0
+    config:
+      column_types:
+        content_id: varchar
+        episode_id: varchar
+        video_id: varchar
+    columns:
+      - name: content_id
+        description: "Unique identifier for unified content"
+        tests:
+          - unique
+          - not_null
+      - name: episode_id
+        description: "Transistor episode ID"
+      - name: video_id
+        description: "YouTube video ID"

--- a/dbt/seeds/seed_content_mapping.csv
+++ b/dbt/seeds/seed_content_mapping.csv
@@ -1,0 +1,1 @@
+content_id,episode_id,video_id

--- a/k8s/1password/onepassworditem-spotify.yaml
+++ b/k8s/1password/onepassworditem-spotify.yaml
@@ -1,0 +1,18 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: spotify-credentials
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: spotify-credentials
+    app.kubernetes.io/component: secret
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  # Reference the 1Password item by name or UUID
+  # Create this item in 1Password with the following fields:
+  #   - client_id: Spotify OAuth2 client ID
+  #   - client_secret: Spotify OAuth2 client secret
+  #   - refresh_token: OAuth2 refresh token from authorization flow
+  #   - show_id: Your Spotify podcast show ID
+  itemPath: "vaults/eleduck-analytics/items/spotify-for-creators"

--- a/k8s/1password/onepassworditem-youtube.yaml
+++ b/k8s/1password/onepassworditem-youtube.yaml
@@ -1,0 +1,18 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: youtube-credentials
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: youtube-credentials
+    app.kubernetes.io/component: secret
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  # Reference the 1Password item by name or UUID
+  # Create this item in 1Password with the following fields:
+  #   - client_id: Google Cloud OAuth2 client ID
+  #   - client_secret: Google Cloud OAuth2 client secret
+  #   - refresh_token: OAuth2 refresh token from authorization flow
+  #   - channel_id: Your YouTube channel ID
+  itemPath: "vaults/eleduck-analytics/items/youtube-analytics"

--- a/k8s/airbyte/deployment.yaml
+++ b/k8s/airbyte/deployment.yaml
@@ -1,0 +1,247 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airbyte-server
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: server
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airbyte
+      component: server
+  template:
+    metadata:
+      labels:
+        app: airbyte
+        component: server
+    spec:
+      serviceAccountName: airbyte
+      containers:
+        - name: airbyte-server
+          image: airbyte/server:0.63.0
+          ports:
+            - containerPort: 8001
+              name: http
+          env:
+            - name: AIRBYTE_VERSION
+              value: "0.63.0"
+            - name: DATABASE_URL
+              value: "jdbc:postgresql://postgres:5432/airbyte_internal"
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: CONFIG_ROOT
+              value: /config
+            - name: WORKSPACE_ROOT
+              value: /workspace
+            - name: TRACKING_STRATEGY
+              value: logging
+            - name: LOG_LEVEL
+              value: INFO
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
+          volumeMounts:
+            - name: airbyte-config
+              mountPath: /config
+            - name: airbyte-workspace
+              mountPath: /workspace
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8001
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: airbyte-config
+          persistentVolumeClaim:
+            claimName: airbyte-config
+        - name: airbyte-workspace
+          persistentVolumeClaim:
+            claimName: airbyte-workspace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airbyte-worker
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airbyte
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: airbyte
+        component: worker
+    spec:
+      serviceAccountName: airbyte
+      containers:
+        - name: airbyte-worker
+          image: airbyte/worker:0.63.0
+          env:
+            - name: AIRBYTE_VERSION
+              value: "0.63.0"
+            - name: DATABASE_URL
+              value: "jdbc:postgresql://postgres:5432/airbyte_internal"
+            - name: DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: CONFIG_ROOT
+              value: /config
+            - name: WORKSPACE_ROOT
+              value: /workspace
+            - name: LOG_LEVEL
+              value: INFO
+            # Spotify credentials
+            - name: SPOTIFY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: spotify-credentials
+                  key: client_id
+            - name: SPOTIFY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: spotify-credentials
+                  key: client_secret
+            - name: SPOTIFY_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: spotify-credentials
+                  key: refresh_token
+            - name: SPOTIFY_SHOW_ID
+              valueFrom:
+                secretKeyRef:
+                  name: spotify-credentials
+                  key: show_id
+            # YouTube credentials
+            - name: YOUTUBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: youtube-credentials
+                  key: client_id
+            - name: YOUTUBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: youtube-credentials
+                  key: client_secret
+            - name: YOUTUBE_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: youtube-credentials
+                  key: refresh_token
+            - name: YOUTUBE_CHANNEL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: youtube-credentials
+                  key: channel_id
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: airbyte-config
+              mountPath: /config
+            - name: airbyte-workspace
+              mountPath: /workspace
+      volumes:
+        - name: airbyte-config
+          persistentVolumeClaim:
+            claimName: airbyte-config
+        - name: airbyte-workspace
+          persistentVolumeClaim:
+            claimName: airbyte-workspace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airbyte-webapp
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: webapp
+    app.kubernetes.io/part-of: eleduck-analytics-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airbyte
+      component: webapp
+  template:
+    metadata:
+      labels:
+        app: airbyte
+        component: webapp
+    spec:
+      containers:
+        - name: airbyte-webapp
+          image: airbyte/webapp:0.63.0
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: AIRBYTE_VERSION
+              value: "0.63.0"
+            - name: API_URL
+              value: "http://airbyte-server:8001/api"
+            - name: INTERNAL_API_HOST
+              value: "airbyte-server:8001"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/k8s/airbyte/kustomization.yaml
+++ b/k8s/airbyte/kustomization.yaml
@@ -16,3 +16,7 @@ configMapGenerator:
       - AIRBYTE_DESTINATION_PORT=5432
       - AIRBYTE_DESTINATION_DATABASE=analytics
       - AIRBYTE_DESTINATION_SCHEMA=raw
+
+commonLabels:
+  app.kubernetes.io/part-of: eleduck-analytics-stack
+  app.kubernetes.io/managed-by: kustomize

--- a/k8s/airbyte/pvc.yaml
+++ b/k8s/airbyte/pvc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airbyte-config
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airbyte-workspace
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/airbyte/service.yaml
+++ b/k8s/airbyte/service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: airbyte-server
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  selector:
+    app: airbyte
+    component: server
+  ports:
+    - name: http
+      port: 8001
+      targetPort: 8001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: airbyte-webapp
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+    app.kubernetes.io/component: webapp
+spec:
+  type: ClusterIP
+  selector:
+    app: airbyte
+    component: webapp
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/k8s/airbyte/serviceaccount.yaml
+++ b/k8s/airbyte/serviceaccount.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airbyte
+  namespace: eleduck-analytics
+  labels:
+    app: airbyte
+    app.kubernetes.io/name: airbyte
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airbyte
+  namespace: eleduck-analytics
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airbyte
+  namespace: eleduck-analytics
+subjects:
+  - kind: ServiceAccount
+    name: airbyte
+    namespace: eleduck-analytics
+roleRef:
+  kind: Role
+  name: airbyte
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: eleduck-analytics
 
 resources:
   - namespace.yaml
-  # 1Password items
+  # 1Password secrets
   - 1password/onepassworditem-postgres.yaml
   - 1password/onepassworditem-airbyte-youtube.yaml
   - 1password/onepassworditem-airbyte-twitch.yaml
@@ -14,9 +14,13 @@ resources:
   - 1password/onepassworditem-airbyte-github.yaml
   - 1password/onepassworditem-airbyte-stripe.yaml
   - 1password/onepassworditem-airbyte-notion.yaml
+  - 1password/onepassworditem-spotify.yaml
   - 1password/onepassworditem-metabase.yaml
   # Infrastructure
   - postgres/
+  # Data pipeline
   - airbyte/
+  # Analytics dashboard
   - metabase/
+  # Data transformation
   - sqlmesh/

--- a/k8s/metabase/deployment.yaml
+++ b/k8s/metabase/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: metabase
     app.kubernetes.io/name: metabase
-    app.kubernetes.io/component: visualization
+    app.kubernetes.io/component: analytics
     app.kubernetes.io/part-of: eleduck-analytics-stack
 spec:
   replicas: 1
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: metabase
-          image: metabase/metabase:latest
+          image: metabase/metabase:v0.50.0
           ports:
             - containerPort: 3000
               name: http
@@ -47,31 +47,37 @@ spec:
                   name: postgres-credentials
                   key: password
 
+            # Site settings
+            - name: MB_SITE_NAME
+              value: "SoypeteTech Analytics"
+            - name: MB_SITE_URL
+              value: "http://localhost:3000"
+            - name: MB_ANON_TRACKING_ENABLED
+              value: "false"
+
             # Jetty configuration
             - name: MB_JETTY_PORT
               value: "3000"
             - name: MB_JETTY_HOST
               value: "0.0.0.0"
 
-            # Disable telemetry
-            - name: MB_ANON_TRACKING_ENABLED
-              value: "false"
-
-            # Site settings
-            - name: MB_SITE_NAME
-              value: "SoypeteTech Analytics"
+            # Performance settings
+            - name: JAVA_OPTS
+              value: "-Xmx2g"
 
             # Timezone
             - name: JAVA_TIMEZONE
               value: "America/Denver"
+            - name: MB_REPORT_TIMEZONE
+              value: "UTC"
 
           resources:
             requests:
               memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
-              cpu: "1"
+              memory: "3Gi"
+              cpu: "2"
 
           livenessProbe:
             httpGet:

--- a/k8s/metabase/kustomization.yaml
+++ b/k8s/metabase/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
   - pvc.yaml
   - deployment.yaml
   - service.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: eleduck-analytics-stack
+  app.kubernetes.io/managed-by: kustomize

--- a/k8s/metabase/service.yaml
+++ b/k8s/metabase/service.yaml
@@ -5,12 +5,14 @@ metadata:
   namespace: eleduck-analytics
   labels:
     app: metabase
+    app.kubernetes.io/name: metabase
+    app.kubernetes.io/component: analytics
 spec:
   type: ClusterIP
-  ports:
-    - port: 3000
-      targetPort: 3000
-      protocol: TCP
-      name: http
   selector:
     app: metabase
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP

--- a/k8s/postgres/configmap-init.yaml
+++ b/k8s/postgres/configmap-init.yaml
@@ -19,6 +19,65 @@ data:
     CREATE DATABASE airbyte_internal;
     CREATE DATABASE metabase_app;
 
+    -- Spotify for Creators: Episode metadata
+    CREATE TABLE IF NOT EXISTS raw.spotify_episodes (
+        id VARCHAR(255) PRIMARY KEY,
+        name VARCHAR(500),
+        description TEXT,
+        release_date DATE,
+        duration_ms INTEGER,
+        explicit BOOLEAN,
+        uri VARCHAR(500),
+        external_urls JSONB,
+        _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- Spotify for Creators: Daily episode performance
+    CREATE TABLE IF NOT EXISTS raw.spotify_episode_performance (
+        episode_id VARCHAR(255) NOT NULL,
+        date DATE NOT NULL,
+        starts INTEGER,
+        streams INTEGER,
+        listeners INTEGER,
+        avg_listen_seconds NUMERIC,
+        _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (episode_id, date)
+    );
+
+    -- Spotify for Creators: Show-level stats
+    CREATE TABLE IF NOT EXISTS raw.spotify_show_stats (
+        date DATE PRIMARY KEY,
+        total_streams BIGINT,
+        followers INTEGER,
+        total_listeners BIGINT,
+        _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- YouTube: Video metadata
+    CREATE TABLE IF NOT EXISTS raw.youtube_videos (
+        id VARCHAR(50) PRIMARY KEY,
+        snippet JSONB,
+        content_details JSONB,
+        _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+
+    -- YouTube: Daily video stats
+    CREATE TABLE IF NOT EXISTS raw.youtube_daily_stats (
+        video_id VARCHAR(50) NOT NULL,
+        date DATE NOT NULL,
+        views INTEGER,
+        watch_time_minutes NUMERIC,
+        average_view_duration NUMERIC,
+        likes INTEGER,
+        comments INTEGER,
+        _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (video_id, date)
+    );
+
+    -- Create indexes for common query patterns
+    CREATE INDEX IF NOT EXISTS idx_spotify_perf_date ON raw.spotify_episode_performance(date);
+    CREATE INDEX IF NOT EXISTS idx_youtube_stats_date ON raw.youtube_daily_stats(date);
+
   02-enable-pg-duckdb.sql: |
     -- Enable pg_duckdb extension
     CREATE EXTENSION IF NOT EXISTS pg_duckdb;

--- a/metabase/dashboard-podcast-performance.json
+++ b/metabase/dashboard-podcast-performance.json
@@ -1,0 +1,269 @@
+{
+  "name": "Podcast Performance",
+  "description": "SoypeteTech podcast analytics across Spotify and YouTube",
+  "parameters": [
+    {
+      "name": "Date Range",
+      "slug": "date_range",
+      "id": "date_range",
+      "type": "date/range",
+      "default": "past30days"
+    }
+  ],
+  "cards": [
+    {
+      "id": 1,
+      "name": "Total Streams (Spotify)",
+      "description": "Total podcast streams on Spotify",
+      "display": "scalar",
+      "visualization_settings": {
+        "scalar.field": "total_streams",
+        "scalar.suffix": " streams"
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT SUM(total_streams) as total_streams FROM analytics.mart_content_performance",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 0,
+        "col": 0,
+        "sizeX": 4,
+        "sizeY": 3
+      }
+    },
+    {
+      "id": 2,
+      "name": "Total Views (YouTube)",
+      "description": "Total video views on YouTube",
+      "display": "scalar",
+      "visualization_settings": {
+        "scalar.field": "total_views",
+        "scalar.suffix": " views"
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT SUM(total_views) as total_views FROM analytics.mart_content_performance",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 0,
+        "col": 4,
+        "sizeX": 4,
+        "sizeY": 3
+      }
+    },
+    {
+      "id": 3,
+      "name": "Streams (30d)",
+      "description": "Spotify streams in the last 30 days with trend",
+      "display": "smartscalar",
+      "visualization_settings": {
+        "scalar.field": "streams",
+        "scalar.comparisons": [
+          {
+            "type": "periodsAgo",
+            "value": 1
+          }
+        ]
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT SUM(spotify_streams) as streams FROM analytics.mart_daily_metrics WHERE metric_date >= CURRENT_DATE - INTERVAL '30 days'",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 0,
+        "col": 8,
+        "sizeX": 4,
+        "sizeY": 3
+      }
+    },
+    {
+      "id": 4,
+      "name": "Views (30d)",
+      "description": "YouTube views in the last 30 days with trend",
+      "display": "smartscalar",
+      "visualization_settings": {
+        "scalar.field": "views",
+        "scalar.comparisons": [
+          {
+            "type": "periodsAgo",
+            "value": 1
+          }
+        ]
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT SUM(youtube_views) as views FROM analytics.mart_daily_metrics WHERE metric_date >= CURRENT_DATE - INTERVAL '30 days'",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 0,
+        "col": 12,
+        "sizeX": 4,
+        "sizeY": 3
+      }
+    },
+    {
+      "id": 5,
+      "name": "Daily Trend",
+      "description": "Daily streams and views over time",
+      "display": "line",
+      "visualization_settings": {
+        "graph.dimensions": ["metric_date"],
+        "graph.metrics": ["spotify_streams", "youtube_views"],
+        "graph.x_axis.title_text": "Date",
+        "graph.y_axis.title_text": "Count",
+        "graph.colors": ["#1DB954", "#FF0000"],
+        "graph.show_values": false,
+        "graph.label_value_formatting": "compact"
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT metric_date, spotify_streams, youtube_views FROM analytics.mart_daily_metrics WHERE metric_date >= CURRENT_DATE - INTERVAL '90 days' ORDER BY metric_date",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 3,
+        "col": 0,
+        "sizeX": 18,
+        "sizeY": 6
+      }
+    },
+    {
+      "id": 6,
+      "name": "Top Episodes by Streams",
+      "description": "Top 10 episodes by Spotify streams",
+      "display": "row",
+      "visualization_settings": {
+        "graph.dimensions": ["title"],
+        "graph.metrics": ["total_streams"],
+        "graph.colors": ["#1DB954"],
+        "graph.x_axis.title_text": "Streams"
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT title, total_streams FROM analytics.mart_content_performance WHERE total_streams > 0 ORDER BY total_streams DESC LIMIT 10",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 9,
+        "col": 0,
+        "sizeX": 9,
+        "sizeY": 6
+      }
+    },
+    {
+      "id": 7,
+      "name": "Top Videos by Views",
+      "description": "Top 10 videos by YouTube views",
+      "display": "row",
+      "visualization_settings": {
+        "graph.dimensions": ["title"],
+        "graph.metrics": ["total_views"],
+        "graph.colors": ["#FF0000"],
+        "graph.x_axis.title_text": "Views"
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT title, total_views FROM analytics.mart_content_performance WHERE total_views > 0 ORDER BY total_views DESC LIMIT 10",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 9,
+        "col": 9,
+        "sizeX": 9,
+        "sizeY": 6
+      }
+    },
+    {
+      "id": 8,
+      "name": "Platform Comparison",
+      "description": "Total consumption by platform",
+      "display": "pie",
+      "visualization_settings": {
+        "pie.dimension": "platform",
+        "pie.metric": "total_consumption",
+        "pie.colors": {
+          "spotify": "#1DB954",
+          "youtube": "#FF0000"
+        },
+        "pie.show_legend": true,
+        "pie.show_total": true
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT platform, total_consumption FROM analytics.mart_platform_comparison",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 15,
+        "col": 0,
+        "sizeX": 6,
+        "sizeY": 6
+      }
+    },
+    {
+      "id": 9,
+      "name": "Content Performance Table",
+      "description": "All content with performance metrics",
+      "display": "table",
+      "visualization_settings": {
+        "table.pivot": false,
+        "table.columns": [
+          {"name": "title", "enabled": true},
+          {"name": "published_date", "enabled": true},
+          {"name": "content_source", "enabled": true},
+          {"name": "total_streams", "enabled": true},
+          {"name": "total_views", "enabled": true},
+          {"name": "total_consumption", "enabled": true}
+        ],
+        "table.cell_column": "total_consumption",
+        "column_settings": {
+          "[\"name\",\"total_streams\"]": {"number_style": "decimal"},
+          "[\"name\",\"total_views\"]": {"number_style": "decimal"},
+          "[\"name\",\"total_consumption\"]": {"number_style": "decimal"}
+        }
+      },
+      "dataset_query": {
+        "type": "native",
+        "native": {
+          "query": "SELECT title, published_date, content_source, total_streams, total_views, total_consumption FROM analytics.mart_content_performance ORDER BY total_consumption DESC",
+          "template-tags": {}
+        },
+        "database": 1
+      },
+      "position": {
+        "row": 15,
+        "col": 6,
+        "sizeX": 12,
+        "sizeY": 6
+      }
+    }
+  ]
+}

--- a/scripts/init-schemas.sql
+++ b/scripts/init-schemas.sql
@@ -12,4 +12,68 @@ GRANT ALL ON SCHEMA staging TO CURRENT_USER;
 GRANT ALL ON SCHEMA analytics TO CURRENT_USER;
 
 -- Set default search path
-ALTER DATABASE analytics SET search_path TO analytics, staging, raw, public;
+ALTER DATABASE eleduck SET search_path TO analytics, staging, raw, public;
+
+--------------------------------------------------------------------------------
+-- RAW LAYER: Landing tables for Airbyte data
+-- These tables are created by Airbyte but we define them for reference
+--------------------------------------------------------------------------------
+
+-- Spotify for Creators: Episode metadata
+CREATE TABLE IF NOT EXISTS raw.spotify_episodes (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(500),
+    description TEXT,
+    release_date DATE,
+    duration_ms INTEGER,
+    explicit BOOLEAN,
+    uri VARCHAR(500),
+    external_urls JSONB,
+    _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Spotify for Creators: Daily episode performance
+CREATE TABLE IF NOT EXISTS raw.spotify_episode_performance (
+    episode_id VARCHAR(255) NOT NULL,
+    date DATE NOT NULL,
+    starts INTEGER,
+    streams INTEGER,
+    listeners INTEGER,
+    avg_listen_seconds NUMERIC,
+    _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (episode_id, date)
+);
+
+-- Spotify for Creators: Show-level stats
+CREATE TABLE IF NOT EXISTS raw.spotify_show_stats (
+    date DATE PRIMARY KEY,
+    total_streams BIGINT,
+    followers INTEGER,
+    total_listeners BIGINT,
+    _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- YouTube: Video metadata
+CREATE TABLE IF NOT EXISTS raw.youtube_videos (
+    id VARCHAR(50) PRIMARY KEY,
+    snippet JSONB,
+    content_details JSONB,
+    _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- YouTube: Daily video stats
+CREATE TABLE IF NOT EXISTS raw.youtube_daily_stats (
+    video_id VARCHAR(50) NOT NULL,
+    date DATE NOT NULL,
+    views INTEGER,
+    watch_time_minutes NUMERIC,
+    average_view_duration NUMERIC,
+    likes INTEGER,
+    comments INTEGER,
+    _airbyte_extracted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (video_id, date)
+);
+
+-- Create indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_spotify_perf_date ON raw.spotify_episode_performance(date);
+CREATE INDEX IF NOT EXISTS idx_youtube_stats_date ON raw.youtube_daily_stats(date);


### PR DESCRIPTION
This commit implements a complete analytics pipeline for SoypeteTech podcast:

Data Sources:
- Spotify for Creators: episodes, daily performance, show stats
- YouTube Analytics: videos, daily stats

DBT Project (dbt/):
- Staging models for Spotify and YouTube data normalization
- Intermediate model (int_content_unified) for cross-platform content mapping
- Mart models: content_performance, daily_metrics, platform_comparison
- Schema tests and documentation
- Seed file for manual episode-to-video mapping

Airbyte Configuration (airbyte/):
- Source configs for Spotify for Creators and YouTube Analytics
- Connection configs for PostgreSQL destination
- Daily sync schedules (6 AM / 7 AM UTC)

Kubernetes Infrastructure (k8s/):
- Airbyte deployment (server, worker, webapp)
- Metabase deployment for dashboards
- 1Password items for Spotify and YouTube credentials

Metabase Dashboard (metabase/):
- 9-card dashboard: KPIs, trends, top content, platform comparison

Also includes:
- Raw schema DDL for podcast tables
- Updated Makefile with DBT and pipeline targets