### PR TITLE
Add MotherDuck integration and Helm deployment

### DIFF
--- a/helm/eleduck-analytics/charts/metabase/templates/deployment.yaml
+++ b/helm/eleduck-analytics/charts/metabase/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
               name: http
           env:
             # Application database (stores Metabase's own data)
+            {{- if .Values.database.useExternal }}
             - name: MB_DB_TYPE
               value: postgres
             - name: MB_DB_HOST
@@ -57,6 +58,13 @@ spec:
               value: "true"
             - name: MB_DB_SSL_MODE
               value: "require"
+            {{- end }}
+            {{- else }}
+            # Use embedded H2 database (default)
+            - name: MB_DB_TYPE
+              value: h2
+            - name: MB_DB_FILE
+              value: /metabase-data/metabase.db
             {{- end }}
 
             # Site settings

--- a/helm/eleduck-analytics/charts/metabase/templates/ingress.yaml
+++ b/helm/eleduck-analytics/charts/metabase/templates/ingress.yaml
@@ -21,4 +21,18 @@ spec:
             name: {{ include "metabase.fullname" . }}
             port:
               number: {{ .Values.service.port }}
+  {{- if .Values.ingress.additionalHosts }}
+  {{- range .Values.ingress.additionalHosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "metabase.fullname" $ }}
+            port:
+              number: {{ $.Values.service.port }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/helm/eleduck-analytics/values-zot.yaml
+++ b/helm/eleduck-analytics/values-zot.yaml
@@ -44,16 +44,15 @@ metabase:
   enabled: true
   image:
     tag: latest
-  siteUrl: "https://analytics.catalyst.local"
+  siteUrl: "https://analytics.soypetetech.local"
+  ingress:
+    additionalHosts:
+      - analytics.tail6fbc5.ts.net
+  database:
+    useExternal: false  # Use embedded H2 database for app data
   persistence:
     storageClass: longhorn
     size: 10Gi
-  # Add hostAliases to bypass DNS resolution issues
-  hostAliases:
-    - ip: "52.8.172.168"
-      hostnames:
-        - "aws-0-us-west-1.pooler.supabase.com"
-  # Metabase app database uses Supabase
   # Analytics queries use MotherDuck (configured in Metabase UI)
 
 # SQLMesh configuration


### PR DESCRIPTION
## Summary
- Integrate MotherDuck as the analytics data warehouse
- Add comprehensive Helm deployment for the analytics stack
- Replace Airbyte dependency with direct MotherDuck connection
- Configure Metabase with flexible database backends

## Key Changes

### MotherDuck Integration
- Add MotherDuck connectivity to analytics pipeline
- Configure SQLMesh to use MotherDuck as the execution engine
- Update deployment to support MotherDuck authentication

### Helm Deployment
- Create umbrella Helm chart for entire analytics stack
- Add Metabase subchart with configurable database backend (H2 or PostgreSQL)
- Configure ingress for both local development and Tailscale access
- Set up persistent storage with Longhorn integration

### Infrastructure
- Add GitHub Actions workflows for building container images
- Create deployment workflow for Foundry cluster
- Add comprehensive deployment documentation
- Configure OpenBao secret management integration

### Configuration
- Add `values-zot.yaml` for local development environment
- Support embedded H2 database for simplified Metabase deployment
- Configure multiple ingress hosts including Tailscale DNS
- Remove Airbyte dependency from deployment

## Test Plan
- [ ] Verify Helm chart deploys successfully
- [ ] Test Metabase connectivity with both H2 and PostgreSQL backends
- [ ] Confirm MotherDuck connection from SQLMesh
- [ ] Validate ingress access via Tailscale
- [ ] Test GitHub Actions workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)